### PR TITLE
feat(#9869): add device storage information to user-devices API

### DIFF
--- a/api/src/services/export/user-devices.js
+++ b/api/src/services/export/user-devices.js
@@ -19,6 +19,7 @@ module.exports = async () => {
     const date = doc.value.date;
     const browser = doc.value.device.userAgent && getBrowser(doc.value.device.userAgent);
     const { apk, android, cht, settings } = doc.value.device.versions;
+    const storage = doc.value.device.storage;
     return {
       user,
       deviceId,
@@ -31,6 +32,8 @@ module.exports = async () => {
       android,
       cht,
       settings,
+      storageFree: storage?.free,
+      storageTotal: storage?.total,
     };
   });
 };

--- a/api/tests/mocha/services/export-data.spec.js
+++ b/api/tests/mocha/services/export-data.spec.js
@@ -343,6 +343,10 @@ describe('Export Data Service', () => {
               // eslint-disable-next-line @stylistic/max-len
               userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36',
               versions: { cht: 'unknown', settings: '4-83c8561a13479b245b295e97401f2f55' },
+              storage: {
+                free: 16713310208,
+                total: 26544680960,
+              },
             },
           },
         },
@@ -359,6 +363,10 @@ describe('Export Data Service', () => {
                 android: '10',
                 cht: 'unknown',
                 settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
+              },
+              storage: {
+                free: 10737418240,
+                total: 42949672960,
               },
             },
           },
@@ -394,7 +402,9 @@ describe('Export Data Service', () => {
           apk: undefined,
           android: undefined,
           cht: 'unknown',
-          settings: '4-83c8561a13479b245b295e97401f2f55'
+          settings: '4-83c8561a13479b245b295e97401f2f55',
+          storageFree: 16713310208,
+          storageTotal: 26544680960
         },
         {
           user: 'chw1',
@@ -407,7 +417,9 @@ describe('Export Data Service', () => {
           apk: 'v1.0.4-4',
           android: '10',
           cht: 'unknown',
-          settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba'
+          settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
+          storageFree: 10737418240,
+          storageTotal: 42949672960
         },
         {
           android: undefined,
@@ -420,6 +432,8 @@ describe('Export Data Service', () => {
           date: '2022-11-29',
           deviceId: 'b1c172d8-82b0-42fd-8401-313796b8c802',
           settings: undefined,
+          storageFree: undefined,
+          storageTotal: undefined,
           user: 'min-data'
         }
       ]);
@@ -436,6 +450,10 @@ describe('Export Data Service', () => {
           device: {
             userAgent: 'Not a real user agent',
             versions: { cht: 'unknown', settings: '4-83c8561a13479b245b295e97401f2f55' },
+            storage: {
+              free: 16713310208,
+              total: 26544680960,
+            },
           },
         },
       },
@@ -451,6 +469,10 @@ describe('Export Data Service', () => {
               android: '10',
               cht: 'unknown',
               settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
+            },
+            storage: {
+              free: 10737418240,
+              total: 42949672960,
             },
           },
         },
@@ -471,7 +493,9 @@ describe('Export Data Service', () => {
         apk: undefined,
         android: undefined,
         cht: 'unknown',
-        settings: '4-83c8561a13479b245b295e97401f2f55'
+        settings: '4-83c8561a13479b245b295e97401f2f55',
+        storageFree: 16713310208,
+        storageTotal: 26544680960
       },
       {
         user: 'chw1',
@@ -484,7 +508,9 @@ describe('Export Data Service', () => {
         apk: 'v1.0.4-4',
         android: '10',
         cht: 'unknown',
-        settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba'
+        settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
+        storageFree: 10737418240,
+        storageTotal: 42949672960
       }
     ]);
     logger.error.callCount.should.equal(1);

--- a/ddocs/users-meta-db/users-meta/views/device_by_user/map.js
+++ b/ddocs/users-meta-db/users-meta/views/device_by_user/map.js
@@ -27,6 +27,10 @@ function(doc) {
           cht: doc.metadata.versions && doc.metadata.versions.app,
           settings: doc.metadata.versions && doc.metadata.versions.settings,
         },
+        storage: doc.device && doc.device.deviceInfo && doc.device.deviceInfo.storage ? {
+          free: doc.device.deviceInfo.storage.free,
+          total: doc.device.deviceInfo.storage.total,
+        } : undefined,
       },
     });
   }

--- a/tests/integration/api/controllers/export-data.spec.js
+++ b/tests/integration/api/controllers/export-data.spec.js
@@ -413,7 +413,8 @@ describe('Export Data V2.0', () => {
       apk,
       android,
       cht,
-      settings
+      settings,
+      storage,
     }) => {
       const [year, month, day] = date.split('-');
       const getUserAgent = () => {
@@ -447,7 +448,9 @@ describe('Export Data V2.0', () => {
             },
             software: {
               androidVersion: android
-            }
+            },
+            // Optional storage information
+            ...(storage ? { storage: { free: storage.free, total: storage.total } } : {})
           }
         }
       };
@@ -591,6 +594,89 @@ describe('Export Data V2.0', () => {
       const result = await utils.request({ path: '/api/v2/export/user-devices' });
 
       expect(result).to.deep.equal([userDataDifferentDevice, userDataLatest]);
+    });
+
+    it('Includes storage fields only when present', async () => {
+      const withStorage = {
+        user: 'with_storage',
+        deviceId: 'aaa-device',
+        date: '2013-03-03',
+        browser: {},
+        storage: { free: 1024, total: 2048 },
+      };
+      const withoutStorage = {
+        user: 'without_storage',
+        deviceId: 'bbb-device',
+        date: '2013-03-03',
+        browser: {},
+      };
+      await saveUsersMetaDocs([withStorage, withoutStorage].map(createTelemetryDoc));
+
+      const result = await utils.request({ path: '/api/v2/export/user-devices' });
+
+      expect(result).to.deep.equal([
+        {
+          user: 'with_storage',
+          deviceId: 'aaa-device',
+          date: '2013-03-03',
+          browser: {},
+          storageFree: 1024,
+          storageTotal: 2048,
+        },
+        {
+          user: 'without_storage',
+          deviceId: 'bbb-device',
+          date: '2013-03-03',
+          browser: {},
+        },
+      ]);
+    });
+
+    it('Picks latest storage per device', async () => {
+      const older = {
+        user: 'chw2',
+        deviceId: 'device-x',
+        date: '2011-11-10',
+        browser: {},
+        storage: { free: 1000, total: 2000 },
+      };
+      const latest = {
+        user: 'chw2',
+        deviceId: 'device-x',
+        date: '2011-11-11',
+        browser: {},
+        storage: { free: 3000, total: 4000 },
+      };
+      const otherDevice = {
+        user: 'chw2',
+        deviceId: 'device-a',
+        date: '2011-11-11',
+        browser: {},
+        storage: { free: 1, total: 2 },
+      };
+      await saveUsersMetaDocs([older, latest, otherDevice].map(createTelemetryDoc));
+
+      const result = await utils.request({ path: '/api/v2/export/user-devices' });
+
+      // Expect order by [user, deviceId] => device-a then device-x
+      expect(result).to.deep.equal([
+        {
+          user: 'chw2',
+          deviceId: 'device-a',
+          date: '2011-11-11',
+          browser: {},
+          storageFree: 1,
+          storageTotal: 2,
+        },
+        {
+          user: 'chw2',
+          deviceId: 'device-x',
+          date: '2011-11-11',
+          browser: {},
+          storageFree: 3000,
+          storageTotal: 4000,
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
# Description

This PR adds device storage information (free and total) to the user-devices API. This allows administrators to monitor CHWs' device storage capacity and usage through the API, helping identify users with storage constraints that might affect application performance.

Closes

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.